### PR TITLE
Describe intersection with RangeFull as within

### DIFF
--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -95,7 +95,7 @@ impl<T: PartialOrd> Intersect<T, RangeFrom<T>> for Range<T> {
 
 impl<T: PartialOrd> Intersect<T, RangeFull> for Range<T> {
     fn intersect(&self, _: &RangeFull) -> Intersection {
-        Intersection::Same
+        Intersection::Within
     }
 }
 


### PR DESCRIPTION
This allows to the following test assertion to pass:

```
assert_eq!($a.intersect(&(..)), Intersection::Within);
```